### PR TITLE
Add a .keyword field to the tracked filters

### DIFF
--- a/conversion_analytics/elasticsearch/component_template.ts
+++ b/conversion_analytics/elasticsearch/component_template.ts
@@ -1,5 +1,6 @@
-import { name as ilmName } from './ilm'
 import querystringParameters, { ParameterType } from './querystringParameters'
+
+import { name as ilmName } from './ilm'
 
 type ElasticType = { type: string, [key: string]: unknown }
 function parameterToElasticType (key: string, parameterType: ParameterType): ElasticType {
@@ -14,7 +15,11 @@ function parameterToElasticType (key: string, parameterType: ParameterType): Ela
 
   switch (parameterType) {
     case 'csv':
-      return { type: 'text', analyzer: 'csv_analyzer' }
+      return {
+        type: 'text',
+        analyzer: 'csv_analyzer',
+        fields: { keyword: { type: 'keyword' } }
+      }
     case 'float':
       return { type: 'float', ignore_malformed: true }
     case 'keyword':

--- a/conversion_analytics/elasticsearch/querystringParameters.ts
+++ b/conversion_analytics/elasticsearch/querystringParameters.ts
@@ -12,6 +12,7 @@ const querystringParameters: Record<string, ParameterType> = {
   languages: 'csv',
   manifest: 'float',
   page: 'float',
+  'partOf.label': 'keyword',
   query: 'text',
   source: 'text',
   'subjects.label': 'csv',

--- a/conversion_analytics/elasticsearch/querystringParameters.ts
+++ b/conversion_analytics/elasticsearch/querystringParameters.ts
@@ -1,24 +1,27 @@
-export type ParameterType = 'text' | 'keyword' | 'float' | 'csv'
+export type ParameterType = "text" | "keyword" | "float" | "csv";
 
 const querystringParameters: Record<string, ParameterType> = {
-  _queryType: 'text',
-  workId: 'keyword',
-  id: 'keyword',
-  availabilities: 'csv',
-  canvas: 'float',
-  current: 'float',
-  'genres.label': 'csv',
-  'items.locations.locationType': 'csv',
-  languages: 'csv',
-  manifest: 'float',
-  page: 'float',
-  'partOf.label': 'keyword',
-  query: 'text',
-  source: 'text',
-  'subjects.label': 'csv',
-  'contributors.agent.label': 'csv',
-  workType: 'csv',
-  resultPosition: 'float'
-}
+  _queryType: "text",
+  color: "keyword",
+  "contributors.agent.label": "csv",
+  "genres.label": "csv",
+  "items.locations.locationType": "csv",
+  "locations.license": "csv",
+  "partOf.label": "keyword",
+  "source.genres.label": "csv",
+  "subjects.label": "csv",
+  availabilities: "csv",
+  canvas: "float",
+  current: "float",
+  id: "keyword",
+  languages: "csv",
+  manifest: "float",
+  page: "float",
+  query: "text",
+  resultPosition: "float",
+  source: "text",
+  workId: "keyword",
+  workType: "csv",
+};
 
-export default querystringParameters
+export default querystringParameters;


### PR DESCRIPTION
This PR adds a `.keyword` field to all `csv` type query parameters, to help @taceybadgerbrook build the dashboards she needs.

It also introduces the `'partOf.label'` query parameter as a keyword, ready for when that filter is introduced.

The changes have already been deployed using the `updateMapping` and `updateByQueryAll` scripts.