### PR TITLE
collect partOf.title instead of partOf.label filter usage

### DIFF
--- a/conversion_analytics/elasticsearch/querystringParameters.ts
+++ b/conversion_analytics/elasticsearch/querystringParameters.ts
@@ -7,7 +7,7 @@ const querystringParameters: Record<string, ParameterType> = {
   "genres.label": "csv",
   "items.locations.locationType": "csv",
   "locations.license": "csv",
-  "partOf.label": "keyword",
+  "partOf.title": "keyword",
   "source.genres.label": "csv",
   "subjects.label": "csv",
   availabilities: "csv",


### PR DESCRIPTION
closes https://github.com/wellcomecollection/wellcomecollection.org/issues/7982

the change has been deployed by running the `updateMapping` and `updateByQueryAll` scripts