### PR TITLE
specify numeric datatype for production_date fields

### DIFF
--- a/conversion_analytics/elasticsearch/querystringParameters.ts
+++ b/conversion_analytics/elasticsearch/querystringParameters.ts
@@ -11,6 +11,8 @@ const querystringParameters: Record<string, ParameterType> = {
   "source.genres.label": "csv",
   "source.subjects.label": "csv",
   "subjects.label": "csv",
+  "production.dates.to": "float",
+  "production.dates.from": "float",
   availabilities: "csv",
   canvas: "float",
   current: "float",


### PR DESCRIPTION
deployed by running the `updateMapping` and `updateByQueryAll` scripts

the dashboard now shows the fields properly populated:

![Screenshot 2022-11-03 at 13 02 16](https://user-images.githubusercontent.com/11006680/199728401-7a11e90c-83e1-453c-8bed-184e31106a9b.png)

closes https://github.com/wellcomecollection/wellcomecollection.org/issues/8775
